### PR TITLE
Add redirect URL for KCD Taipei 2025 booth application form

### DIFF
--- a/_redirects/2025-booth.md
+++ b/_redirects/2025-booth.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+title: "KCD Taipei 2025 Booth Application"
+description: "KCD Taipei 2025 Booth Application"
+redirect_to: "https://docs.google.com/forms/d/e/1FAIpQLSeG4ZxTmFPjghlxViZ_XF-z4_fsuIjbjaPFSfuR6Wy5XrjCrw/viewform?usp=header"
+---


### PR DESCRIPTION
## PR Description

This PR adds a short redirect link for the Kubernetes Community Days (KCD) Taipei 2025 community booth application form.

## New redirect link:
https://i.kcd.taipei/2025-booth

## Redirect target:
https://docs.google.com/forms/d/e/1FAIpQLSeG4ZxTmFPjghlxViZ_XF-z4_fsuIjbjaPFSfuR6Wy5XrjCrw/viewform?usp=header

